### PR TITLE
Modify header, feature link color and style on WORKS page

### DIFF
--- a/works.html
+++ b/works.html
@@ -48,10 +48,7 @@ a:hover{color:var(--key-blue)}
   color:var(--key-blue);letter-spacing:.5px;transition:opacity .2s
 }
 .logo:hover{opacity:.8}
-.contents-label{
-  font-family:'Inter',sans-serif;font-size:20px;font-weight:400;
-  color:var(--text-muted);letter-spacing:2px
-}
+.works-logo{color:var(--text)}
 
 /* ───────── メイン特集 ───────── */
 .main-feature{padding:40px 0;border-bottom:2px solid var(--key-blue)}
@@ -59,6 +56,8 @@ a:hover{color:var(--key-blue)}
 .feature-title-jp{
   font-size:28px;font-weight:600;color:var(--key-blue);line-height:1.3
 }
+.feature-title-jp a{color:var(--key-blue)}
+.feature-title-jp a:hover{color:var(--text)}
 .feature-title-en{
   font-family:'Inter',sans-serif;font-size:18px;font-weight:600;
   color:var(--text-muted)
@@ -66,7 +65,7 @@ a:hover{color:var(--key-blue)}
 .feature-publisher{font-size:14px;color:var(--text-muted);margin-bottom:12px}
 .feature-page{
   display:inline-block;background:var(--key-blue);color:#fff;
-  padding:4px 18px;border-radius:9999px;font-size:14px;font-weight:500
+  padding:4px 18px;border-radius:6px;font-size:14px;font-weight:500
 }
 
 /* ───────── 作品リスト ───────── */
@@ -130,8 +129,7 @@ a:hover{color:var(--key-blue)}
   <!-- 1/3 TOP ---------------------------------------------------------------->
   <div class="box box-top">
     <header class="header">
-      <a href="index.html" class="logo">TETSUYA&nbsp;SANO</a>
-      <div class="contents-label">WORKS</div>
+      <a href="index.html" class="logo works-logo">WORKS</a>
     </header>
 
     <section class="main-feature">


### PR DESCRIPTION
## Summary
- move WORKS text into the header link and remove author name
- style the WORKS link in black
- color the featured title link with the page key blue and change to black on hover
- reduce the roundness of the 2023 badge

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a9a523ec0832598c323a42a448ff4