### PR TITLE
Group news items by year

### DIFF
--- a/news.html
+++ b/news.html
@@ -40,6 +40,12 @@ html,body{height:100%;background:var(--paper);color:var(--ink);
 
 /* ---- CONTENTS LIST ---- */
 ul{list-style:none;padding:0;margin:0;}
+.year{
+  margin-top:calc(var(--gap)*2);
+  margin-bottom:calc(var(--gap)/2);
+  font-size:1.25rem;
+  font-weight:700;
+}
 .item{
   display:flex;flex-wrap:wrap;gap:6px;
   margin-bottom:var(--gap);
@@ -73,6 +79,8 @@ ul{list-style:none;padding:0;margin:0;}
   <!-- CONTENTS LIST -->
   <ul>
 
+    <li class="year">2025</li>
+
     <li class="item">
       <span class="date">2025-05-16</span><span class="sep">│</span>
       <span class="text"><b>エッセイ〈母へ〉第15回公開</b> 「yom&nbsp;yom」連載最新話</span>
@@ -82,6 +90,8 @@ ul{list-style:none;padding:0;margin:0;}
       <span class="date">2025-05-04</span><span class="sep">│</span>
       <span class="text"><b>ジャ・ジャンクー監督『新世紀ロマンティクス』</b>推薦コメント</span>
     </li>
+
+    <li class="year">2024</li>
 
     <li class="item">
       <span class="date">2024-11-15</span><span class="sep">│</span>
@@ -102,6 +112,8 @@ ul{list-style:none;padding:0;margin:0;}
       <span class="date">2024-03-01</span><span class="sep">│</span>
       <span class="text"><b>「別冊文藝春秋」３月号</b>インタビュー掲載</span>
     </li>
+
+    <li class="year">2023</li>
 
     <li class="item">
       <span class="date">2023-12-01</span><span class="sep">│</span>


### PR DESCRIPTION
## Summary
- add `year` style and HTML markers
- group news entries under headings for 2025, 2024 and 2023

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a9b38240883259bc4a887f484c514