### PR TITLE
Fix works page style and header link

### DIFF
--- a/works.html
+++ b/works.html
@@ -60,7 +60,7 @@ a:hover{color:var(--key-blue)}
 .feature-title-jp a:hover{color:var(--text)}
 .feature-title-en{
   font-family:'Inter',sans-serif;font-size:18px;font-weight:600;
-  color:var(--text-muted)
+  color:#000
 }
 .feature-publisher{font-size:14px;color:var(--text-muted);margin-bottom:12px}
 .feature-page{
@@ -129,7 +129,7 @@ a:hover{color:var(--key-blue)}
   <!-- 1/3 TOP ---------------------------------------------------------------->
   <div class="box box-top">
     <header class="header">
-      <a href="index.html" class="logo works-logo">WORKS</a>
+      <span class="logo works-logo">WORKS</span>
     </header>
 
     <section class="main-feature">


### PR DESCRIPTION
## Summary
- remove the homepage link on the WORKS header
- make the "06" label black

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a9d47cd308325825601fb9f41f05c