### PR TITLE
Remove footer name from about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -423,7 +423,6 @@ footer a
 
 <footer>
   <div class="footer-content">
-    <div class="footer-name">佐野徹夜</div>
     
     <div class="footer-links">
       <div class="social-links">


### PR DESCRIPTION
## Summary
- remove author name from the About page footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bff4d4aa883259b4c4c3b519c2451