### PR TITLE
Improve responsive layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,6 +12,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/aohal.html
+++ b/aohal.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/fragments.html
+++ b/fragments.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/hozon.html
+++ b/hozon.html
@@ -2,8 +2,10 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1">
   <title>PDF Link Opener</title>
   <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
     body{font-family:sans-serif;margin:2rem;max-width:640px}
     textarea{width:100%;height:8rem}
     button{margin-top:1rem;padding:.6rem 1.2rem;font-size:1rem}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/jisage.html
+++ b/jisage.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>字下げツール（リアルタイム版）</title>
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 body{font:16px/1.6 system-ui,sans-serif;margin:2rem}
 textarea{width:100%;height:8rem;margin:.6rem 0;font:14px/1.5 monospace}
 .counter{font-size:.9rem;color:#666}

--- a/kaigyousakujo.html
+++ b/kaigyousakujo.html
@@ -2,9 +2,12 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Clean-Paste Live</title>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 body{font:16px/1.6 system-ui,sans-serif;margin:2rem;max-width:44rem}
 textarea{width:100%;min-height:10rem;margin:.8rem 0;padding:.6rem;font:15px/1.6 monospace}
 textarea[readonly]{background:#f7f7f7}

--- a/kimitsuki.html
+++ b/kimitsuki.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/konosekainii.html
+++ b/konosekainii.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/mojisuu.html
+++ b/mojisuu.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>文字数 & 原稿用紙カウンタ</title>
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 body{font:16px/1.6 system-ui,sans-serif;margin:2rem}
 label{margin-right:.8rem}
 textarea{width:100%;height:10rem;margin:.5rem 0;font:14px/1.5 monospace}

--- a/news.html
+++ b/news.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/pdfketugou.html
+++ b/pdfketugou.html
@@ -2,8 +2,10 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
   <title>pdf合体</title>
   <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
     body{font-family:sans-serif;text-align:center;margin:5rem 0}
     button{padding:.8rem 2rem;font-size:1rem;cursor:pointer}
   </style>

--- a/sayonara.html
+++ b/sayonara.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/scenario.html
+++ b/scenario.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TV脚本フォーマッタ</title>
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 body{font:16px/1.6 system-ui,sans-serif;margin:2rem;max-width:46rem}
 textarea{width:100%;min-height:10rem;margin:.8rem 0;padding:.6rem;font:15px/1.6 monospace}
 textarea[readonly]{background:#f7f7f7}

--- a/texttohtml.html
+++ b/texttohtml.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Plain-Text → .html ダウンロード</title>
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
   body{font-family:system-ui, sans-serif; margin:2em; max-width:40rem;}
   textarea{width:100%;height:14rem;font-family:monospace;margin-bottom:1rem;}
   button{padding:.6rem 1.2rem;font-size:1rem;}

--- a/toumei.html
+++ b/toumei.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/txttougou.html
+++ b/txttougou.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Text Merger</title>
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
   body{font-family:system-ui;margin:2rem}
   #log{white-space:pre;max-height:8rem;overflow:auto;background:#f6f6f6;padding:.5rem}
 </style>

--- a/works.html
+++ b/works.html
@@ -13,6 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500&display=swap" rel="stylesheet">
 
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 :root{
   --bg:#FCFCFC;
   --text:#1A1A1A;

--- a/zenkaku.html
+++ b/zenkaku.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>半角→全角コンバータ</title>
 <style>
+*{box-sizing:border-box;} img{max-width:100%;height:auto;}
 body{font:16px/1.6 system-ui,sans-serif;margin:2rem}
 textarea{width:100%;height:9rem;margin:.6rem 0;font:14px/1.5 monospace}
 label{display:block;font-size:.9rem;color:#666}


### PR DESCRIPTION
## Summary
- add viewport meta tags to missing pages
- inject global box-sizing reset and responsive image rule on all pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c2035b5e08325960a20d104cb53d0