### PR TITLE
Fix news link style

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,17 @@ li:hover{
   transform:translateX(3px);
 }
 
+/* Style news links within the list */
+#news li a{
+  color:inherit;
+  text-decoration:none;
+  font:inherit;
+  transition:color .3s ease;
+}
+#news li a:hover{
+  color:var(--hover-blue);
+}
+
 /* ── 新作メーター（改良版）─────────────────── */
 .progress-container{
   background:var(--surface);


### PR DESCRIPTION
## Summary
- improve `index.html` styles so news links use the same font
- allow news links to inherit text color and highlight on hover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c4df40f248325b53cca615c403e37