### PR TITLE
Adjust layout and copy

### DIFF
--- a/about.html
+++ b/about.html
@@ -324,8 +324,8 @@ footer{
 @media (max-width:768px){
   .hero{
     flex-direction:column;
-    text-align:center;
-    align-items:center;
+    text-align:left;
+    align-items:flex-start;
   }
   
   .profile-image{
@@ -351,12 +351,10 @@ footer{
       <a href="index.html">HOME</a>
       <a href="about.html">ABOUT</a>
       <a href="works.html">WORKS</a>
-      <a href="news.html">NEWS</a>
     </nav>
   </header>
 
   <main>
-    <a href="index.html" class="back-link">HOME</a>
     
     <section class="hero">
       <img src="profile.jpg" alt="佐野徹夜" class="profile-image">
@@ -416,7 +414,7 @@ footer{
         
         <div class="timeline-card">
           <div class="timeline-year">2024</div>
-          <div class="timeline-content">コミック『一年に一度しか会えない君の話。』1巻刊行。<br>短篇集『君に贈る15ページ』に書き下ろし「わたしたちの教室」収録。</div>
+          <div class="timeline-content">コミック『一年に一度しか会えない君の話。』1巻刊行。<br>短編アンソロジー『君に贈る15ページ』に書き下ろし「わたしたちの教室」収録。</div>
         </div>
       </div>
     </section>

--- a/aohal.html
+++ b/aohal.html
@@ -346,13 +346,15 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
   .footer-content{
-    grid-template-columns:1fr;
-    gap:3rem;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:1.5rem;
     text-align:center;
   }
   
@@ -425,7 +427,6 @@ footer{
   </header>
 
   <main>
-    <a href="works.html" class="back-link">WORKS</a>
     
     <h1>アオハル・ポイント</h1>
     

--- a/fragments.html
+++ b/fragments.html
@@ -345,13 +345,15 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
   .footer-content{
-    grid-template-columns:1fr;
-    gap:3rem;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:1.5rem;
     text-align:center;
   }
   
@@ -424,7 +426,6 @@ footer{
   </header>
 
   <main>
-    <a href="works.html" class="back-link">WORKS</a>
     
     <h1>君は月夜に光り輝く +Fragments</h1>
     

--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
@@ -352,19 +352,18 @@ footer{
 }
 
 @media (max-width:768px){
-  .works-grid{
-    grid-template-columns:repeat(2,1fr);
-    gap:1rem;
-  }
-  
   .progress-container{
     padding:1.5rem;
+  }
+  .works-grid{
+    grid-template-columns:repeat(3,1fr);
+    gap:1rem;
   }
 }
 
 @media (max-width:480px){
   .works-grid{
-    grid-template-columns:1fr;
+    grid-template-columns:repeat(3,1fr);
   }
 }
 </style>
@@ -416,7 +415,7 @@ footer{
     <h2><a href="news.html">NEWS</a></h2>
     <ul>
       <li>2025-06-13　<a href="https://www.bookbang.jp/yomyom/content/essay/dm/13746" target="_blank" rel="noopener">エッセイ〈母へ〉第16回公開「充電ができなくて」</a></li>
-      <li>2024-12-25　<a href="https://www.kadokawa.co.jp/product/322407000894/" target="_blank" rel="noopener">短篇集『君に贈る15ページ』発売、書き下ろし「わたしたちの教室」収録</a></li>
+      <li>2024-12-25　<a href="https://www.kadokawa.co.jp/product/322407000894/" target="_blank" rel="noopener">短編アンソロジー『君に贈る15ページ』発売、書き下ろし「わたしたちの教室」収録</a></li>
       <li>2023-11-09　<a href="https://www.kawade.co.jp/np/isbn/9784309031293/" target="_blank" rel="noopener">長篇『透明になれなかった僕たちのために』刊行（河出書房新社）</a></li>
     </ul>
   </section>

--- a/kimitsuki.html
+++ b/kimitsuki.html
@@ -358,13 +358,15 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
   .footer-content{
-    grid-template-columns:1fr;
-    gap:3rem;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:1.5rem;
     text-align:center;
   }
   
@@ -437,7 +439,6 @@ footer{
   </header>
 
   <main>
-    <a href="works.html" class="back-link">WORKS</a>
     
     <h1>君は月夜に光り輝く</h1>
     

--- a/konosekainii.html
+++ b/konosekainii.html
@@ -368,13 +368,15 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
   .footer-content{
-    grid-template-columns:1fr;
-    gap:3rem;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:1.5rem;
     text-align:center;
   }
   
@@ -447,7 +449,6 @@ footer{
   </header>
 
   <main>
-    <a href="works.html" class="back-link">WORKS</a>
     
     <section class="hero">
       <a href="https://www.amazon.co.jp/dp/4048934147" target="_blank" rel="noopener">

--- a/news.html
+++ b/news.html
@@ -348,6 +348,10 @@ footer a
     text-align:left;
     font-size:0.8rem;
   }
+  footer{
+    margin-top:0;
+    padding:3rem 0;
+  }
 }
 </style>
 </head>
@@ -364,10 +368,7 @@ footer a
   </header>
 
   <main>
-    <a href="index.html" class="back-link">HOME</a>
-    
-    <h1>News</h1>
-    
+
     <div class="main-content">
     <section class="year-section">
       <div class="year-header">
@@ -387,16 +388,6 @@ footer a
         </li>
 
 
-        <li class="news-item">
-          <div class="news-date">05-16</div>
-          <div class="news-content">
-            <div class="news-title">
-              <a href="https://www.bookbang.jp/yomyom/content/essay/dm/13500" target="_blank" rel="noopener">
-                エッセイ〈母へ〉第15回公開「あなたはいつも優しくて」
-              </a>
-            </div>
-          </div>
-        </li>
         
         <li class="news-item">
           <div class="news-date">04-26</div>
@@ -409,27 +400,7 @@ footer a
           </div>
         </li>
 
-        <li class="news-item">
-          <div class="news-date">04-18</div>
-          <div class="news-content">
-            <div class="news-title">
-              <a href="https://www.bookbang.jp/yomyom/content/essay/dm/13036" target="_blank" rel="noopener">
-                エッセイ〈母へ〉第14回公開「諦められなくて」
-              </a>
-            </div>
-          </div>
-        </li>
 
-        <li class="news-item">
-          <div class="news-date">02-21</div>
-          <div class="news-content">
-            <div class="news-title">
-              <a href="https://www.bookbang.jp/yomyom/content/essay/dm/12307" target="_blank" rel="noopener">
-                エッセイ〈母へ〉第13回公開「毎日冴えなくて」
-              </a>
-            </div>
-          </div>
-        </li>
       </ul>
     </section>
 
@@ -444,7 +415,7 @@ footer a
           <div class="news-content">
             <div class="news-title">
               <a href="https://www.kadokawa.co.jp/product/322407000894/" target="_blank" rel="noopener">
-                短篇集『君に贈る15ページ』発売、書き下ろし「わたしたちの教室」収録
+                短編アンソロジー『君に贈る15ページ』発売、書き下ろし「わたしたちの教室」収録
               </a>
             </div>
           </div>

--- a/sayonara.html
+++ b/sayonara.html
@@ -346,13 +346,15 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
   .footer-content{
-    grid-template-columns:1fr;
-    gap:3rem;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:1.5rem;
     text-align:center;
   }
   
@@ -425,7 +427,6 @@ footer{
   </header>
 
   <main>
-    <a href="works.html" class="back-link">WORKS</a>
     
     <h1>さよなら世界の終わり</h1>
     

--- a/toumei.html
+++ b/toumei.html
@@ -346,13 +346,15 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
   .footer-content{
-    grid-template-columns:1fr;
-    gap:3rem;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:1.5rem;
     text-align:center;
   }
   
@@ -425,7 +427,6 @@ footer{
   </header>
 
   <main>
-    <a href="works.html" class="back-link">WORKS</a>
     
     <h1>透明になれなかった僕たちのために</h1>
     

--- a/works.html
+++ b/works.html
@@ -367,7 +367,7 @@ footer{
 
 @media(max-width:768px){
   footer{
-    margin-top:8rem;
+    margin-top:0;
     padding:3rem 0;
   }
   
@@ -500,10 +500,6 @@ footer{
   </header>
 
   <main>
-    <a href="index.html" class="back-link">HOME</a>
-    
-    <h1>Works</h1>
-    
     <section class="works-section">
       <div class="section-intro">
         <h2>長編小説</h2>


### PR DESCRIPTION
## Summary
- ensure footer has no extra margin on small screens
- keep three covers per row on mobile
- remove redundant page headings and back links
- fix footer layout on mobile for works pages
- update publication text to "短編アンソロジー『君に贈る15ページ』"
- drop older "母へ" news items

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d02c360688325b86fe2a9033ec259